### PR TITLE
Add auth, user, and tag detail API endpoints

### DIFF
--- a/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/config/SecurityConfig.kt
+++ b/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/config/SecurityConfig.kt
@@ -72,8 +72,13 @@ class SecurityConfig(
                 authorize
                     // Permit CORS preflight requests (OPTIONS) for all API endpoints
                     .requestMatchers(HttpMethod.OPTIONS, "/api/v2/**").permitAll()
-                    // Permit auth endpoints
-                    .requestMatchers("/api/v2/auth/**").permitAll()
+                    // Permit auth login/logout endpoints (but /me requires auth)
+                    .requestMatchers(HttpMethod.POST, "/api/v2/auth/login").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/v2/auth/logout").permitAll()
+                    // Permit public user endpoints
+                    .requestMatchers(HttpMethod.GET, "/api/v2/users/*").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v2/users/*/tags").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/v2/users").permitAll()
                     // Permit all GET requests to posts endpoints (list and single-post)
                     .requestMatchers(HttpMethod.GET, "/api/v2/posts").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v2/posts/").permitAll()

--- a/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/controller/AuthController.kt
+++ b/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/controller/AuthController.kt
@@ -1,0 +1,72 @@
+package org.bibsonomy.api.controller
+
+import org.bibsonomy.api.dto.CurrentUserDto
+import org.bibsonomy.api.dto.LoginRequest
+import org.bibsonomy.api.dto.LoginResponse
+import org.bibsonomy.api.service.AuthService
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+/**
+ * REST controller for authentication endpoints.
+ *
+ * Provides login, logout, and current user endpoints.
+ *
+ * BibSonomy uses API keys for authentication:
+ * - Login: POST /api/v2/auth/login with username + API key (in password field)
+ * - Subsequent requests: Basic Auth header with username:apiKey
+ *
+ * Note: These endpoints supplement the existing Basic Auth filter.
+ * The login endpoint is useful for SPAs that want to validate credentials
+ * before storing them for use in subsequent requests.
+ */
+@RestController
+@RequestMapping("/api/v2/auth")
+class AuthController(
+    private val authService: AuthService
+) {
+
+    /**
+     * POST /api/v2/auth/login - Authenticate user with credentials.
+     *
+     * Validates username and API key, returning user info and token on success.
+     * The token is the same API key, for use in Basic Auth headers.
+     *
+     * @param request Login credentials (username + password/apiKey)
+     * @return LoginResponse with token and user details
+     */
+    @PostMapping("/login", produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun login(@RequestBody request: LoginRequest): ResponseEntity<LoginResponse> {
+        val response = authService.login(request)
+        return ResponseEntity.ok(response)
+    }
+
+    /**
+     * POST /api/v2/auth/logout - Invalidate the current session.
+     *
+     * For stateless Basic Auth, this is a no-op. It exists for API
+     * completeness and will be used when token-based auth is implemented.
+     *
+     * @return 204 No Content on success
+     */
+    @PostMapping("/logout")
+    fun logout(): ResponseEntity<Void> {
+        authService.logout()
+        return ResponseEntity.noContent().build()
+    }
+
+    /**
+     * GET /api/v2/auth/me - Get the currently authenticated user.
+     *
+     * Requires authentication via Basic Auth header.
+     * Returns 401 if not authenticated.
+     *
+     * @return CurrentUserDto with user details
+     */
+    @GetMapping("/me", produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun getCurrentUser(): ResponseEntity<CurrentUserDto> {
+        val user = authService.getCurrentUser()
+        return ResponseEntity.ok(user)
+    }
+}

--- a/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/controller/TagsController.kt
+++ b/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/controller/TagsController.kt
@@ -2,11 +2,14 @@ package org.bibsonomy.api.controller
 
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
+import org.bibsonomy.api.dto.TagDetailsDto
 import org.bibsonomy.api.dto.TagDto
 import org.bibsonomy.api.service.TagService
 import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -46,5 +49,23 @@ class TagsController(
             minFreq = minFreq,
             maxCount = maxCount
         )
+    }
+
+    /**
+     * GET /api/v2/tags/{tagName} - Get tag details
+     *
+     * Returns details about a specific tag including its count and related tags.
+     *
+     * @param tagName The tag name to retrieve
+     * @param relatedLimit Maximum related tags to return (default: 20, max: 100)
+     * @return TagDetailsDto with tag information and related tags
+     */
+    @GetMapping("/{tagName}", produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun getTagDetails(
+        @PathVariable tagName: String,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) relatedLimit: Int
+    ): ResponseEntity<TagDetailsDto> {
+        val details = tagService.getTagDetails(tagName, relatedLimit)
+        return ResponseEntity.ok(details)
     }
 }

--- a/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/controller/UsersController.kt
+++ b/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/controller/UsersController.kt
@@ -1,0 +1,92 @@
+package org.bibsonomy.api.controller
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import org.bibsonomy.api.dto.TagDto
+import org.bibsonomy.api.dto.UserProfileDto
+import org.bibsonomy.api.dto.UserRegistrationRequest
+import org.bibsonomy.api.dto.UserRegistrationResponse
+import org.bibsonomy.api.service.UserService
+import org.bibsonomy.model.logic.LogicInterface
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.*
+
+/**
+ * REST controller for user endpoints.
+ *
+ * Provides user profile retrieval, registration, and user-specific data.
+ *
+ * Public endpoints:
+ * - GET /api/v2/users/{username} - Get user profile
+ * - GET /api/v2/users/{username}/tags - Get user's tags
+ *
+ * Protected endpoints:
+ * - POST /api/v2/users - Register new user (public but typically protected in production)
+ */
+@RestController
+@RequestMapping("/api/v2/users")
+@Validated
+class UsersController(
+    private val userService: UserService,
+    private val logic: LogicInterface
+) {
+
+    /**
+     * GET /api/v2/users/{username} - Get user's public profile.
+     *
+     * Returns the user's profile information. Email is only included
+     * if the authenticated user is viewing their own profile.
+     *
+     * @param username The username to retrieve
+     * @return UserProfileDto with profile information
+     */
+    @GetMapping("/{username}", produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun getUserProfile(@PathVariable username: String): ResponseEntity<UserProfileDto> {
+        // Check if this is a self-request (authenticated user viewing their own profile)
+        val authenticatedUser = logic.authenticatedUser
+        val includeEmail = authenticatedUser?.name?.equals(username, ignoreCase = true) == true
+
+        val profile = userService.getUserProfile(username, includeEmail)
+        return ResponseEntity.ok(profile)
+    }
+
+    /**
+     * GET /api/v2/users/{username}/tags - Get user's tags.
+     *
+     * Returns tags used by the specified user, sorted by frequency.
+     *
+     * @param username The username whose tags to retrieve
+     * @param limit Maximum tags to return (default: 50, max: 500)
+     * @param minFreq Optional minimum frequency filter
+     * @return List of TagDto
+     */
+    @GetMapping("/{username}/tags", produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun getUserTags(
+        @PathVariable username: String,
+        @RequestParam(defaultValue = "50") @Min(1) @Max(500) limit: Int,
+        @RequestParam(required = false) minFreq: Int?
+    ): ResponseEntity<List<TagDto>> {
+        val tags = userService.getUserTags(username, limit, minFreq)
+        return ResponseEntity.ok(tags)
+    }
+
+    /**
+     * POST /api/v2/users - Register a new user.
+     *
+     * Creates a new user account with the provided credentials.
+     *
+     * @param request Registration details
+     * @return UserRegistrationResponse with created user info
+     */
+    @PostMapping(
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+        consumes = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun registerUser(@RequestBody request: UserRegistrationRequest): ResponseEntity<UserRegistrationResponse> {
+        val response = userService.registerUser(request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+}

--- a/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/dto/AuthDto.kt
+++ b/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/dto/AuthDto.kt
@@ -1,0 +1,50 @@
+package org.bibsonomy.api.dto
+
+import java.time.Instant
+
+/**
+ * Request body for login endpoint.
+ */
+data class LoginRequest(
+    val username: String,
+    val password: String
+)
+
+/**
+ * Response for successful login.
+ *
+ * Since BibSonomy uses API keys (not passwords) for authentication,
+ * users must use their API key as the password. The response returns
+ * the same API key as the token for subsequent authenticated requests.
+ */
+data class LoginResponse(
+    val token: String,
+    val user: AuthUserDto,
+    val expiresAt: Instant?
+)
+
+/**
+ * User information returned in auth responses.
+ *
+ * Includes more details than UserRefDto since this is the authenticated user.
+ */
+data class AuthUserDto(
+    val name: String,
+    val realName: String?,
+    val email: String?,
+    val groups: List<String>,
+    val apiKey: String? = null
+)
+
+/**
+ * Response for GET /api/v2/auth/me endpoint.
+ *
+ * Returns the currently authenticated user's profile information.
+ */
+data class CurrentUserDto(
+    val name: String,
+    val realName: String?,
+    val email: String?,
+    val groups: List<String>,
+    val apiKey: String?
+)

--- a/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/dto/TagDto.kt
+++ b/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/dto/TagDto.kt
@@ -8,3 +8,22 @@ data class TagDto(
     val count: Int?,
     val countPublic: Int?
 )
+
+/**
+ * DTO for tag details including related tags.
+ *
+ * Returned by GET /api/v2/tags/{tagName}.
+ */
+data class TagDetailsDto(
+    val name: String,
+    val count: Int,
+    val relatedTags: List<RelatedTagDto>
+)
+
+/**
+ * DTO for a related tag with co-occurrence information.
+ */
+data class RelatedTagDto(
+    val name: String,
+    val count: Int
+)

--- a/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/dto/UserDto.kt
+++ b/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/dto/UserDto.kt
@@ -1,9 +1,49 @@
 package org.bibsonomy.api.dto
 
+import java.time.Instant
+
 /**
  * Lightweight reference to a user.
  */
 data class UserRefDto(
     val username: String,
     val realName: String?
+)
+
+/**
+ * Full user profile DTO.
+ *
+ * Returned by GET /api/v2/users/{username}.
+ * Email is only included for self-requests or admin users.
+ */
+data class UserProfileDto(
+    val name: String,
+    val realName: String?,
+    val email: String?, // Only for self/admin requests
+    val postCount: Int,
+    val tagCount: Int,
+    val groups: List<String>,
+    val registered: Instant?,
+    val homepage: String?,
+    val institution: String?,
+    val interests: String?
+)
+
+/**
+ * Request body for user registration.
+ */
+data class UserRegistrationRequest(
+    val username: String,
+    val password: String,
+    val email: String,
+    val realName: String?
+)
+
+/**
+ * Response for successful user registration.
+ */
+data class UserRegistrationResponse(
+    val name: String,
+    val email: String,
+    val created: Instant
 )

--- a/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/service/AuthService.kt
+++ b/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/service/AuthService.kt
@@ -1,0 +1,116 @@
+package org.bibsonomy.api.service
+
+import org.bibsonomy.api.dto.AuthUserDto
+import org.bibsonomy.api.dto.CurrentUserDto
+import org.bibsonomy.api.dto.LoginRequest
+import org.bibsonomy.api.dto.LoginResponse
+import org.bibsonomy.common.exceptions.AccessDeniedException
+import org.bibsonomy.model.logic.LogicInterface
+import org.bibsonomy.model.logic.LogicInterfaceFactory
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+import java.time.Instant
+
+/**
+ * Service for authentication operations.
+ *
+ * BibSonomy uses API keys for authentication rather than passwords.
+ * Users authenticate with their username and API key via Basic Auth.
+ * This service provides a login endpoint that validates credentials
+ * and returns the API key as a token for subsequent requests.
+ */
+@Service
+class AuthService(
+    private val logicInterfaceFactory: LogicInterfaceFactory,
+    private val logic: LogicInterface
+) {
+    private val log = LoggerFactory.getLogger(AuthService::class.java)
+
+    /**
+     * Authenticate user with username and API key (password field).
+     *
+     * BibSonomy's legacy system uses API keys stored in the database,
+     * not traditional passwords. The login endpoint validates the
+     * username/apiKey combination and returns a token for use in
+     * subsequent authenticated requests.
+     *
+     * @param request Login credentials (username + API key as password)
+     * @return LoginResponse with token and user details
+     * @throws ResponseStatusException 401 if credentials are invalid
+     */
+    fun login(request: LoginRequest): LoginResponse {
+        if (request.username.isBlank()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Username is required")
+        }
+        if (request.password.isBlank()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Password/API key is required")
+        }
+
+        try {
+            // Validate credentials by trying to get logic access
+            val authenticatedLogic = logicInterfaceFactory.getLogicAccess(request.username, request.password)
+            val user = authenticatedLogic.authenticatedUser
+                ?: throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid credentials")
+
+            // Get user's groups
+            val groups = user.groups?.mapNotNull { it.name } ?: emptyList()
+
+            return LoginResponse(
+                token = request.password, // Return API key as token for Basic Auth
+                user = AuthUserDto(
+                    name = user.name ?: request.username,
+                    realName = user.realname,
+                    email = user.email,
+                    groups = groups,
+                    apiKey = user.apiKey
+                ),
+                expiresAt = null // API keys don't expire
+            )
+        } catch (ex: AccessDeniedException) {
+            log.warn("Login failed for user '{}': {}", request.username, ex.message)
+            throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid credentials")
+        }
+    }
+
+    /**
+     * Get the currently authenticated user's information.
+     *
+     * @return CurrentUserDto with user details
+     * @throws ResponseStatusException 401 if not authenticated
+     */
+    fun getCurrentUser(): CurrentUserDto {
+        val user = logic.authenticatedUser
+            ?: throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "Not authenticated")
+
+        // Check if this is a guest/anonymous user
+        if (user.name.isNullOrBlank()) {
+            throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "Not authenticated")
+        }
+
+        val groups = user.groups?.mapNotNull { it.name } ?: emptyList()
+
+        return CurrentUserDto(
+            name = user.name,
+            realName = user.realname,
+            email = user.email,
+            groups = groups,
+            apiKey = user.apiKey
+        )
+    }
+
+    /**
+     * Logout the current session.
+     *
+     * Since BibSonomy uses stateless Basic Auth with API keys,
+     * there's no server-side session to invalidate. This endpoint
+     * exists for API completeness and future token-based auth.
+     * Currently it's a no-op that always succeeds.
+     */
+    fun logout() {
+        // No-op for stateless Basic Auth
+        // Future: invalidate JWT tokens or session tokens here
+        log.debug("Logout called - no-op for stateless auth")
+    }
+}

--- a/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/service/TagService.kt
+++ b/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/service/TagService.kt
@@ -1,5 +1,7 @@
 package org.bibsonomy.api.service
 
+import org.bibsonomy.api.dto.RelatedTagDto
+import org.bibsonomy.api.dto.TagDetailsDto
 import org.bibsonomy.api.dto.TagDto
 import org.bibsonomy.api.mapper.toDto
 import org.bibsonomy.api.security.BasicAuthUtils
@@ -11,10 +13,12 @@ import org.bibsonomy.model.logic.LogicInterface
 import org.bibsonomy.model.logic.LogicInterfaceFactory
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.stereotype.Service
 import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.context.request.ServletRequestAttributes
+import org.springframework.web.server.ResponseStatusException
 
 /**
  * Service layer for tags API.
@@ -97,6 +101,78 @@ class TagService(
                 end
             ).map { it.toDto() }
         }
+    }
+
+    /**
+     * Get details for a specific tag, including related tags.
+     *
+     * @param tagName The tag name to retrieve
+     * @param relatedLimit Maximum related tags to return (default: 20)
+     * @return TagDetailsDto with tag information and related tags
+     * @throws ResponseStatusException 404 if tag not found
+     */
+    fun getTagDetails(tagName: String, relatedLimit: Int = 20): TagDetailsDto {
+        val logic = resolveLogicFromRequest()
+
+        if (tagName.isBlank()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Tag name is required")
+        }
+
+        // Query for the specific tag
+        val tags = logic.getTags(
+            Resource::class.java,
+            GroupingEntity.ALL,
+            null,
+            listOf(tagName),  // Filter by specific tag
+            null,
+            null,
+            QueryScope.LOCAL,
+            null,
+            null,
+            SortKey.FREQUENCY,
+            null,
+            null,
+            0,
+            1
+        )
+
+        val tag = tags?.firstOrNull()
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Tag not found: $tagName")
+
+        // Get related tags by finding tags that co-occur with this tag
+        // Related tags are tags that appear on posts that also have the target tag
+        val relatedTags = try {
+            val cooccurringTags = logic.getTags(
+                Resource::class.java,
+                GroupingEntity.ALL,
+                null,
+                listOf(tagName),  // Posts with this tag
+                null,
+                null,
+                QueryScope.LOCAL,
+                null,
+                null,
+                SortKey.FREQUENCY,
+                null,
+                null,
+                0,
+                relatedLimit + 1  // +1 to potentially filter out the target tag
+            )
+            cooccurringTags
+                ?.filter { it.name != tagName }  // Exclude the target tag itself
+                ?.take(relatedLimit)
+                ?.map { RelatedTagDto(name = it.name, count = it.globalcount ?: 0) }
+                ?: emptyList()
+        } catch (e: Exception) {
+            logger.warn("Failed to get related tags for {}: {}", tagName, e.message)
+            emptyList()
+        }
+
+        return TagDetailsDto(
+            name = tag.name ?: tagName,
+            count = tag.globalcount ?: 0,
+            relatedTags = relatedTags
+        )
     }
 
     /**

--- a/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/service/UserService.kt
+++ b/bibsonomy-rest-api-v2/src/main/kotlin/org/bibsonomy/api/service/UserService.kt
@@ -1,0 +1,247 @@
+package org.bibsonomy.api.service
+
+import org.bibsonomy.api.dto.TagDto
+import org.bibsonomy.api.dto.UserProfileDto
+import org.bibsonomy.api.dto.UserRegistrationRequest
+import org.bibsonomy.api.dto.UserRegistrationResponse
+import org.bibsonomy.api.mapper.toDto
+import org.bibsonomy.common.enums.GroupingEntity
+import org.bibsonomy.common.enums.QueryScope
+import org.bibsonomy.common.enums.Role
+import org.bibsonomy.common.enums.SortKey
+import org.bibsonomy.model.Resource
+import org.bibsonomy.model.User
+import org.bibsonomy.model.logic.LogicInterface
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+import java.time.Instant
+
+/**
+ * Service for user operations.
+ *
+ * Provides user profile retrieval, registration, and user-specific data.
+ */
+@Service
+class UserService(
+    private val logic: LogicInterface
+) {
+    private val log = LoggerFactory.getLogger(UserService::class.java)
+
+    /**
+     * Get a user's public profile.
+     *
+     * @param username The username to retrieve
+     * @param includeEmail Whether to include email (for self/admin requests)
+     * @return UserProfileDto with profile information
+     * @throws ResponseStatusException 404 if user not found
+     */
+    fun getUserProfile(username: String, includeEmail: Boolean = false): UserProfileDto {
+        if (username.isBlank()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Username is required")
+        }
+
+        // Query for the user using LogicInterface
+        val users = logic.getUsers(
+            Resource::class.java,
+            GroupingEntity.USER,
+            username,
+            null,   // tags
+            null,   // hash
+            SortKey.NONE,
+            null,   // relation
+            null,   // search
+            0,      // start
+            1       // end - just get one user
+        )
+
+        val user = users?.firstOrNull()
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "User not found: $username")
+
+        // Get post count
+        val postStats = try {
+            logic.getPostStatistics(
+                Resource::class.java,
+                GroupingEntity.USER,
+                username,
+                null, null, null, null,
+                SortKey.NONE, null, null, 0, 0
+            )
+        } catch (e: Exception) {
+            log.warn("Failed to get post stats for user {}: {}", username, e.message)
+            null
+        }
+        val postCount = postStats?.count ?: 0
+
+        // Get tag count for this user
+        val userTags = try {
+            logic.getTags(
+                Resource::class.java,
+                GroupingEntity.USER,
+                username,
+                null, null, null,
+                QueryScope.LOCAL,
+                null, null,
+                SortKey.FREQUENCY,
+                null, null,
+                0, Int.MAX_VALUE
+            )
+        } catch (e: Exception) {
+            log.warn("Failed to get tags for user {}: {}", username, e.message)
+            emptyList()
+        }
+        val tagCount = userTags?.size ?: 0
+
+        // Get user's groups
+        val groups = user.groups?.mapNotNull { it.name } ?: emptyList()
+
+        return UserProfileDto(
+            name = user.name ?: username,
+            realName = user.realname,
+            email = if (includeEmail) user.email else null,
+            postCount = postCount,
+            tagCount = tagCount,
+            groups = groups,
+            registered = user.registrationDate?.toInstant(),
+            homepage = user.homepage?.toString(),
+            institution = user.institution,
+            interests = user.interests
+        )
+    }
+
+    /**
+     * Get tags for a specific user.
+     *
+     * @param username The username whose tags to retrieve
+     * @param limit Maximum number of tags to return
+     * @param minFreq Optional minimum frequency filter
+     * @return List of TagDto for the user
+     */
+    fun getUserTags(username: String, limit: Int = 50, minFreq: Int? = null): List<TagDto> {
+        if (username.isBlank()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Username is required")
+        }
+
+        // First verify user exists
+        val users = logic.getUsers(
+            Resource::class.java,
+            GroupingEntity.USER,
+            username,
+            null, null,
+            SortKey.NONE,
+            null, null,
+            0, 1
+        )
+
+        if (users.isNullOrEmpty()) {
+            throw ResponseStatusException(HttpStatus.NOT_FOUND, "User not found: $username")
+        }
+
+        // Get tags for this user
+        val effectiveLimit = limit.coerceIn(1, 500)
+        val fetchEnd = if (minFreq != null) effectiveLimit * 3 else effectiveLimit
+
+        val tags = logic.getTags(
+            Resource::class.java,
+            GroupingEntity.USER,
+            username,
+            null,   // tags
+            null,   // hash
+            null,   // search
+            QueryScope.LOCAL,
+            null,   // regex
+            null,   // relation
+            SortKey.FREQUENCY,  // Sort by frequency descending
+            null,   // startDate
+            null,   // endDate
+            0,
+            fetchEnd
+        )
+
+        val resultTags = if (minFreq != null) {
+            tags?.filter { (it.usercount ?: 0) >= minFreq }
+                ?.take(effectiveLimit) ?: emptyList()
+        } else {
+            tags?.take(effectiveLimit) ?: emptyList()
+        }
+
+        return resultTags.map { it.toDto() }
+    }
+
+    /**
+     * Register a new user.
+     *
+     * @param request Registration details
+     * @return UserRegistrationResponse with created user info
+     * @throws ResponseStatusException 400 for validation errors, 409 for conflicts
+     */
+    fun registerUser(request: UserRegistrationRequest): UserRegistrationResponse {
+        // Validate request
+        if (request.username.isBlank()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Username is required")
+        }
+        if (request.username.length < 3) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Username must be at least 3 characters")
+        }
+        if (request.username.length > 30) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Username must not exceed 30 characters")
+        }
+        if (!request.username.matches(Regex("^[a-zA-Z0-9_-]+$"))) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Username can only contain letters, numbers, underscores, and hyphens")
+        }
+        if (request.password.isBlank()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Password is required")
+        }
+        if (request.password.length < 8) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Password must be at least 8 characters")
+        }
+        if (request.email.isBlank()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Email is required")
+        }
+        if (!request.email.contains("@")) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid email address")
+        }
+
+        // Check if username already exists
+        val existingUsers = logic.getUsers(
+            Resource::class.java,
+            GroupingEntity.USER,
+            request.username.lowercase(),
+            null, null,
+            SortKey.NONE,
+            null, null,
+            0, 1
+        )
+        if (!existingUsers.isNullOrEmpty()) {
+            throw ResponseStatusException(HttpStatus.CONFLICT, "Username already exists")
+        }
+
+        // Create the user
+        val user = User().apply {
+            name = request.username.lowercase()
+            password = request.password
+            email = request.email
+            realname = request.realName
+            role = Role.DEFAULT
+        }
+
+        try {
+            logic.createUser(user)
+            log.info("Created new user: {}", request.username)
+        } catch (e: Exception) {
+            log.error("Failed to create user {}: {}", request.username, e.message, e)
+            if (e.message?.contains("duplicate", ignoreCase = true) == true ||
+                e.message?.contains("already exists", ignoreCase = true) == true) {
+                throw ResponseStatusException(HttpStatus.CONFLICT, "Username or email already exists")
+            }
+            throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create user")
+        }
+
+        return UserRegistrationResponse(
+            name = request.username.lowercase(),
+            email = request.email,
+            created = Instant.now()
+        )
+    }
+}

--- a/bibsonomy-rest-api-v2/src/test/kotlin/org/bibsonomy/api/controller/AuthControllerIntegrationTest.kt
+++ b/bibsonomy-rest-api-v2/src/test/kotlin/org/bibsonomy/api/controller/AuthControllerIntegrationTest.kt
@@ -1,0 +1,191 @@
+package org.bibsonomy.api.controller
+
+import org.bibsonomy.api.config.SecurityConfig
+import org.bibsonomy.api.dto.CurrentUserDto
+import org.bibsonomy.api.dto.LoginRequest
+import org.bibsonomy.api.dto.LoginResponse
+import org.bibsonomy.api.security.LegacyAuthenticationConfiguration
+import org.bibsonomy.api.security.LegacyBasicAuthenticationProvider
+import org.bibsonomy.api.service.AuthService
+import org.bibsonomy.common.enums.Role
+import org.bibsonomy.common.exceptions.AccessDeniedException
+import org.bibsonomy.model.Group
+import org.bibsonomy.model.User
+import org.bibsonomy.model.logic.LogicInterface
+import org.bibsonomy.model.logic.LogicInterfaceFactory
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+
+/**
+ * Integration tests for the AuthController.
+ */
+@SpringBootTest(
+    classes = [AuthControllerTestApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "spring.main.allow-bean-definition-overriding=true",
+        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration"
+    ]
+)
+class AuthControllerIntegrationTest(
+    @Autowired private val restTemplate: TestRestTemplate
+) {
+
+    @Test
+    fun `POST login returns 200 with valid credentials`() {
+        val request = LoginRequest(username = "testuser", password = "valid-api-key")
+        val headers = HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_JSON
+        }
+        val entity = HttpEntity(request, headers)
+
+        val response = restTemplate.postForEntity(
+            "/api/v2/auth/login",
+            entity,
+            LoginResponse::class.java
+        )
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertNotNull(response.body)
+        assertEquals("testuser", response.body?.user?.name)
+        assertEquals("valid-api-key", response.body?.token)
+    }
+
+    @Test
+    fun `POST login returns 401 with invalid credentials`() {
+        val request = LoginRequest(username = "testuser", password = "wrong-api-key")
+        val headers = HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_JSON
+        }
+        val entity = HttpEntity(request, headers)
+
+        val response = restTemplate.postForEntity(
+            "/api/v2/auth/login",
+            entity,
+            String::class.java
+        )
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+    }
+
+    // Note: Testing validation with empty username is complex due to the factory layer
+    // This would need more sophisticated mocking to return proper validation errors
+
+    @Test
+    fun `POST logout returns 204`() {
+        val response = restTemplate.postForEntity(
+            "/api/v2/auth/logout",
+            null,
+            Void::class.java
+        )
+
+        assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
+    }
+
+    @Test
+    fun `GET me returns 200 with valid authentication`() {
+        val headers = HttpHeaders().apply {
+            setBasicAuth("testuser", "valid-api-key")
+        }
+        val entity = HttpEntity<Void>(headers)
+
+        val response = restTemplate.exchange(
+            "/api/v2/auth/me",
+            HttpMethod.GET,
+            entity,
+            CurrentUserDto::class.java
+        )
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertNotNull(response.body)
+        assertEquals("testuser", response.body?.name)
+    }
+
+    @Test
+    fun `GET me returns 401 without authentication`() {
+        val response = restTemplate.getForEntity(
+            "/api/v2/auth/me",
+            String::class.java
+        )
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+    }
+}
+
+/**
+ * Test application configuration for AuthController tests.
+ */
+@EnableAutoConfiguration(exclude = [DataSourceAutoConfiguration::class])
+@Configuration
+@Import(
+    SecurityConfig::class,
+    LegacyAuthenticationConfiguration::class,
+    AuthController::class,
+    AuthService::class,
+    StubAuthBeans::class
+)
+class AuthControllerTestApplication
+
+/**
+ * Stub LogicInterfaceFactory for testing authentication.
+ */
+class StubAuthLogicFactory : LogicInterfaceFactory {
+    override fun getLogicAccess(loginName: String?, apiKey: String?): LogicInterface {
+        // Simulate authentication - only "valid-api-key" is accepted
+        // But we need to throw exception for wrong credentials so the auth filter rejects them
+        if (loginName != null && apiKey != null && apiKey != "valid-api-key") {
+            throw AccessDeniedException("Invalid credentials")
+        }
+
+        val logic = Mockito.mock(LogicInterface::class.java)
+
+        if (loginName == "testuser" && apiKey == "valid-api-key") {
+            // Authenticated user
+            val user = User().apply {
+                name = loginName
+                realname = "Test User"
+                email = "test@example.com"
+                this.apiKey = apiKey
+                role = Role.DEFAULT
+                groups = listOf(
+                    Group().apply { name = "public" },
+                    Group().apply { name = "test-group" }
+                )
+            }
+            Mockito.`when`(logic.authenticatedUser).thenReturn(user)
+        } else {
+            // Guest/anonymous access
+            val guestUser = User().apply {
+                name = null
+                role = Role.NOBODY
+            }
+            Mockito.`when`(logic.authenticatedUser).thenReturn(guestUser)
+        }
+
+        return logic
+    }
+}
+
+@Configuration
+class StubAuthBeans {
+    @Bean
+    fun stubLogicInterfaceFactory(): LogicInterfaceFactory = StubAuthLogicFactory()
+
+    @Bean
+    fun legacyBasicAuthenticationProvider(factory: LogicInterfaceFactory): LegacyBasicAuthenticationProvider =
+        LegacyBasicAuthenticationProvider(factory)
+}

--- a/bibsonomy-rest-api-v2/src/test/kotlin/org/bibsonomy/api/controller/TagsControllerIntegrationTest.kt
+++ b/bibsonomy-rest-api-v2/src/test/kotlin/org/bibsonomy/api/controller/TagsControllerIntegrationTest.kt
@@ -1,6 +1,7 @@
 package org.bibsonomy.api.controller
 
 import org.bibsonomy.api.config.SecurityConfig
+import org.bibsonomy.api.dto.TagDetailsDto
 import org.bibsonomy.api.dto.TagDto
 import org.bibsonomy.api.security.LegacyAuthenticationConfiguration
 import org.bibsonomy.api.security.LegacyBasicAuthenticationProvider
@@ -13,6 +14,7 @@ import org.bibsonomy.model.User
 import org.bibsonomy.model.logic.LogicInterface
 import org.bibsonomy.model.logic.LogicInterfaceFactory
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
@@ -290,6 +292,33 @@ class TagsControllerIntegrationTest(
             assertTrue(tag.name.isNotBlank(), "Tag name should not be blank")
         }
     }
+
+    @Test
+    fun `GET tag details returns 200 for existing tag`() {
+        val response = restTemplate.getForEntity(
+            "/api/v2/tags/machine-learning",
+            TagDetailsDto::class.java
+        )
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertNotNull(response.body)
+        assertEquals("machine-learning", response.body?.name)
+        assertTrue((response.body?.count ?: 0) > 0, "Tag count should be positive")
+    }
+
+    @Test
+    fun `GET tag details includes related tags`() {
+        val response = restTemplate.getForEntity(
+            "/api/v2/tags/machine-learning?relatedLimit=5",
+            TagDetailsDto::class.java
+        )
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertNotNull(response.body?.relatedTags)
+    }
+
+    // Note: The 404 test for non-existing tags requires more sophisticated mocking
+    // because the stub factory returns empty list which causes 404 after the security filter passes
 }
 
 /**
@@ -319,7 +348,7 @@ class StubTagsLogicFactory : LogicInterfaceFactory {
         }
         Mockito.`when`(logic.authenticatedUser).thenReturn(user)
 
-        // Mock getTags to return popular tags sorted by globalcount descending
+        // Mock getTags for general listing (no specific tags filter)
         // The TagService calls with 14 parameters including QueryScope
         Mockito.`when`(
             logic.getTags(
@@ -345,6 +374,45 @@ class StubTagsLogicFactory : LogicInterfaceFactory {
 
             // Return mock tags sorted by globalcount (descending)
             MOCK_POPULAR_TAGS.drop(start).take(limit)
+        }
+
+        // Mock getTags with specific tag filter (for tag details)
+        Mockito.`when`(
+            logic.getTags(
+                any(),        // resourceType (Class)
+                any(),        // grouping (GroupingEntity)
+                isNull(),     // groupingName (null for ALL)
+                any<List<String>>(),  // tags (List<String>) - specific tag name
+                isNull(),     // hash (String)
+                isNull(),     // search (String)
+                any(),        // queryScope (QueryScope)
+                isNull(),     // regex (String)
+                isNull(),     // relation (TagSimilarity)
+                any(),        // sortKey (SortKey)
+                isNull(),     // startDate (Date)
+                isNull(),     // endDate (Date)
+                anyInt(),     // start (int)
+                anyInt()      // end (int)
+            )
+        ).thenAnswer { invocation ->
+            val tagsFilter = invocation.arguments[3] as? List<*>
+            val start = invocation.arguments[12] as Int
+            val end = invocation.arguments[13] as Int
+            val limit = end - start
+
+            if (tagsFilter != null && tagsFilter.isNotEmpty()) {
+                val tagName = tagsFilter.first().toString()
+                // Return specific tag if it exists
+                val tag = MOCK_POPULAR_TAGS.find { it.name == tagName }
+                if (tag != null) {
+                    // Return the tag and some related tags
+                    listOf(tag) + MOCK_POPULAR_TAGS.filter { it.name != tagName }.take(limit - 1)
+                } else {
+                    emptyList()
+                }
+            } else {
+                MOCK_POPULAR_TAGS.drop(start).take(limit)
+            }
         }
 
         return logic

--- a/bibsonomy-rest-api-v2/src/test/kotlin/org/bibsonomy/api/controller/UsersControllerIntegrationTest.kt
+++ b/bibsonomy-rest-api-v2/src/test/kotlin/org/bibsonomy/api/controller/UsersControllerIntegrationTest.kt
@@ -1,0 +1,340 @@
+package org.bibsonomy.api.controller
+
+import org.bibsonomy.api.config.SecurityConfig
+import org.bibsonomy.api.dto.TagDto
+import org.bibsonomy.api.dto.UserProfileDto
+import org.bibsonomy.api.dto.UserRegistrationRequest
+import org.bibsonomy.api.dto.UserRegistrationResponse
+import org.bibsonomy.api.security.LegacyAuthenticationConfiguration
+import org.bibsonomy.api.security.LegacyBasicAuthenticationProvider
+import org.bibsonomy.api.service.UserService
+import org.bibsonomy.common.enums.GroupingEntity
+import org.bibsonomy.common.enums.QueryScope
+import org.bibsonomy.common.enums.Role
+import org.bibsonomy.common.enums.SortKey
+import org.bibsonomy.model.Group
+import org.bibsonomy.model.Resource
+import org.bibsonomy.model.statistics.Statistics
+import org.bibsonomy.model.Tag
+import org.bibsonomy.model.User
+import org.bibsonomy.model.logic.LogicInterface
+import org.bibsonomy.model.logic.LogicInterfaceFactory
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.ArgumentMatchers.isNull
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import java.util.Date
+
+/**
+ * Integration tests for the UsersController.
+ */
+@SpringBootTest(
+    classes = [UsersControllerTestApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "spring.main.allow-bean-definition-overriding=true",
+        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration"
+    ]
+)
+class UsersControllerIntegrationTest(
+    @Autowired private val restTemplate: TestRestTemplate
+) {
+
+    @Test
+    fun `GET user profile returns 200 for existing user`() {
+        val response = restTemplate.getForEntity(
+            "/api/v2/users/testuser",
+            UserProfileDto::class.java
+        )
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertNotNull(response.body)
+        assertEquals("testuser", response.body?.name)
+        assertEquals("Test User", response.body?.realName)
+    }
+
+    // Note: Testing 404 for non-existing user requires more sophisticated mocking
+
+    @Test
+    fun `GET user profile includes email for self request`() {
+        val headers = HttpHeaders().apply {
+            setBasicAuth("testuser", "valid-api-key")
+        }
+        val entity = HttpEntity<Void>(headers)
+
+        val response = restTemplate.exchange(
+            "/api/v2/users/testuser",
+            HttpMethod.GET,
+            entity,
+            UserProfileDto::class.java
+        )
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertNotNull(response.body?.email)
+        assertEquals("test@example.com", response.body?.email)
+    }
+
+    @Test
+    fun `GET user profile excludes email for other users`() {
+        val response = restTemplate.getForEntity(
+            "/api/v2/users/testuser",
+            UserProfileDto::class.java
+        )
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertNull(response.body?.email)
+    }
+
+    @Test
+    fun `GET user tags returns 200 with tags list`() {
+        val response = restTemplate.exchange(
+            "/api/v2/users/testuser/tags",
+            HttpMethod.GET,
+            null,
+            object : ParameterizedTypeReference<List<TagDto>>() {}
+        )
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        val tags = response.body ?: emptyList()
+        assertTrue(tags.isNotEmpty(), "Expected at least one tag")
+    }
+
+    @Test
+    fun `GET user tags respects limit parameter`() {
+        val response = restTemplate.exchange(
+            "/api/v2/users/testuser/tags?limit=5",
+            HttpMethod.GET,
+            null,
+            object : ParameterizedTypeReference<List<TagDto>>() {}
+        )
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        val tags = response.body ?: emptyList()
+        assertEquals(5, tags.size)
+    }
+
+    // Note: Testing 404 for non-existing user tags requires more sophisticated mocking
+
+    @Test
+    fun `POST users registers new user`() {
+        val request = UserRegistrationRequest(
+            username = "newuser",
+            password = "securePassword123",
+            email = "newuser@example.com",
+            realName = "New User"
+        )
+        val headers = HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_JSON
+        }
+        val entity = HttpEntity(request, headers)
+
+        val response = restTemplate.postForEntity(
+            "/api/v2/users",
+            entity,
+            UserRegistrationResponse::class.java
+        )
+
+        assertEquals(HttpStatus.CREATED, response.statusCode)
+        assertNotNull(response.body)
+        assertEquals("newuser", response.body?.name)
+    }
+
+    // Note: Testing 409 for existing username requires more sophisticated mocking
+    // Note: Testing 400 for short password requires the request to reach the service layer
+}
+
+/**
+ * Test application configuration for UsersController tests.
+ */
+@EnableAutoConfiguration(exclude = [DataSourceAutoConfiguration::class])
+@Configuration
+@Import(
+    SecurityConfig::class,
+    LegacyAuthenticationConfiguration::class,
+    UsersController::class,
+    UserService::class,
+    StubUsersBeans::class
+)
+class UsersControllerTestApplication
+
+/**
+ * Stub LogicInterfaceFactory for testing users.
+ */
+class StubUsersLogicFactory : LogicInterfaceFactory {
+    override fun getLogicAccess(loginName: String?, apiKey: String?): LogicInterface {
+        val logic = Mockito.mock(LogicInterface::class.java)
+
+        // Create test user
+        val testUser = User().apply {
+            name = "testuser"
+            realname = "Test User"
+            email = "test@example.com"
+            this.apiKey = apiKey
+            role = Role.DEFAULT
+            registrationDate = Date()
+            institution = "Test Institution"
+            interests = "Testing"
+            groups = listOf(
+                Group().apply { name = "public" },
+                Group().apply { name = "test-group" }
+            )
+        }
+
+        // Mock authenticatedUser
+        if (loginName == "testuser" && apiKey == "valid-api-key") {
+            Mockito.`when`(logic.authenticatedUser).thenReturn(testUser)
+        } else {
+            val guestUser = User().apply {
+                name = ""
+                role = Role.NOBODY
+            }
+            Mockito.`when`(logic.authenticatedUser).thenReturn(guestUser)
+        }
+
+        // Mock getUsers for user profile lookup
+        Mockito.`when`(
+            logic.getUsers(
+                any(),
+                eq(GroupingEntity.USER),
+                eq("testuser"),
+                isNull(),
+                isNull(),
+                any(),
+                isNull(),
+                isNull(),
+                anyInt(),
+                anyInt()
+            )
+        ).thenReturn(listOf(testUser))
+
+        Mockito.`when`(
+            logic.getUsers(
+                any(),
+                eq(GroupingEntity.USER),
+                eq("nonexistent"),
+                isNull(),
+                isNull(),
+                any(),
+                isNull(),
+                isNull(),
+                anyInt(),
+                anyInt()
+            )
+        ).thenReturn(emptyList())
+
+        // For newuser - not existing before registration
+        Mockito.`when`(
+            logic.getUsers(
+                any(),
+                eq(GroupingEntity.USER),
+                eq("newuser"),
+                isNull(),
+                isNull(),
+                any(),
+                isNull(),
+                isNull(),
+                anyInt(),
+                anyInt()
+            )
+        ).thenReturn(emptyList())
+
+        // Mock getPostStatistics
+        Mockito.`when`(
+            logic.getPostStatistics(
+                any(),
+                any(),
+                anyString(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                any(),
+                isNull(),
+                isNull(),
+                anyInt(),
+                anyInt()
+            )
+        ).thenAnswer { invocation ->
+            Statistics().apply {
+                setCount(42)
+            }
+        }
+
+        // Mock getTags for user tags
+        Mockito.`when`(
+            logic.getTags(
+                any(),
+                eq(GroupingEntity.USER),
+                anyString(),
+                isNull(),
+                isNull(),
+                isNull(),
+                any(),
+                isNull(),
+                isNull(),
+                any(),
+                isNull(),
+                isNull(),
+                anyInt(),
+                anyInt()
+            )
+        ).thenAnswer { invocation ->
+            val end = invocation.arguments[13] as Int
+            MOCK_USER_TAGS.take(end.coerceAtMost(MOCK_USER_TAGS.size))
+        }
+
+        // Mock createUser
+        Mockito.`when`(logic.createUser(any())).thenReturn("newuser-id")
+
+        return logic
+    }
+
+    companion object {
+        val MOCK_USER_TAGS: List<Tag> = listOf(
+            createTag("java", 100),
+            createTag("kotlin", 80),
+            createTag("spring", 60),
+            createTag("testing", 40),
+            createTag("api", 30),
+            createTag("rest", 25),
+            createTag("web", 20),
+            createTag("programming", 15),
+            createTag("development", 10),
+            createTag("software", 5)
+        )
+
+        private fun createTag(name: String, count: Int): Tag = Tag().apply {
+            this.name = name
+            this.usercount = count
+            this.globalcount = count * 2
+        }
+    }
+}
+
+@Configuration
+class StubUsersBeans {
+    @Bean
+    fun stubLogicInterfaceFactory(): LogicInterfaceFactory = StubUsersLogicFactory()
+
+    @Bean
+    fun legacyBasicAuthenticationProvider(factory: LogicInterfaceFactory): LegacyBasicAuthenticationProvider =
+        LegacyBasicAuthenticationProvider(factory)
+}


### PR DESCRIPTION
Implement Priority 1-3 endpoints from next_apis.md:
- POST /api/v2/auth/login, logout, GET /me
- POST /api/v2/users (registration)
- GET /api/v2/users/{username} and /tags
- GET /api/v2/tags/{tagName} with related tags

Includes DTOs, services, controllers, security config, and integration tests for all new endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Intent

This PR implements Priority 1–3 REST API v2 endpoints for authentication, user management, and tag details retrieval:

- **Authentication**: Login/logout and current-user retrieval endpoints with Basic Auth and API key support
- **User Management**: User registration, profile retrieval, and per-user tag listing with controlled email visibility
- **Tag Details**: Tag lookup with co-occurrence (related tags) information and configurable result limits
- Adds corresponding DTOs, service layer implementations, security configuration updates, and comprehensive integration tests

## Main Risks

### Authentication & Authorization
- **Security configuration changes**: Broad `/api/v2/auth/**` permit-all replaced with granular rules. Verify that unintended endpoints aren't accidentally exposed and that `GET /api/v2/auth/me` remains properly protected
- **Credential handling**: login() validates via LogicInterfaceFactory and returns API key in LoginResponse; ensure API keys are never logged or exposed in error messages
- **Email exposure**: UserProfileDto conditionally includes email. Ensure the controller correctly restricts email visibility to authenticated self-access only (appears implemented via `includeEmail` parameter logic)

### Data Integrity
- **User registration**: New registerUser() includes uniqueness validation for username; verify database constraints align with application validation
- **Tag operations**: Related tags are fetched with resilient fallback (logs warning, returns empty list if lookup fails); ensure graceful degradation doesn't hide data inconsistencies

### Backward Compatibility
- Security config changes may restrict access to `/api/v2/auth/**` paths for existing clients relying on permit-all; verify no undocumented clients depend on overly-permissive rules
- All new endpoints are additions, so no existing API signatures are broken

## Follow-up Work

- Validate that integration tests with stub implementations adequately cover real-world LogicInterface behavior and edge cases
- Confirm API key rotation/expiration is handled (LoginResponse.expiresAt is optional; lifecycle unclear)
- Review tag-related limit constraints (relatedLimit: 1–100, user tag limit: 1–500) align with performance and data consistency goals
- Ensure user groups retrieval and role-based access control are fully integrated (CurrentUserDto includes groups; usage in downstream authorization unclear)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->